### PR TITLE
feat: named custom config with save/edit/delete

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -32,6 +32,26 @@
         <optgroup label="Locations" id="locationsOptGroup">
         </optgroup>
       </select>
+      <div class="flex items-center gap-2 mt-2">
+        <input type="text" name="configName" placeholder="Configuration name"
+          class="flex-1 py-1 px-2 text-sm border border-borderDark rounded focus:outline-none focus:border-purple hidden">
+        <div class="flex gap-2">
+          <button name="saveConfig" class="text-sm text-purple hover:text-purpleDark hidden">
+            Save
+          </button>
+          <button name="cancelEdit" class="text-sm text-gray-600 hover:text-gray-800 hidden">
+            Cancel
+          </button>
+          <div name="configActions" class="flex gap-2 hidden">
+            <button name="editConfig" class="text-sm text-blue-600 hover:text-blue-800">
+              Edit
+            </button>
+            <button name="deleteConfig" class="text-sm text-red-600 hover:text-red-800">
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div>


### PR DESCRIPTION
Add custom configuration management feature

Changes:
- Add save/load for custom configurations
- Add name input for configurations
- Add save/edit/delete buttons
- Maintain edit mode for custom config
- Add keyboard shortcuts (Enter to save, Escape to cancel)

This feature allows users to:
- Save current settings with custom names
- Edit existing saved configurations
- Delete unwanted configurations
- Easily switch between saved configurations